### PR TITLE
Fix: send touch event to SampleApp.LcdF.UI instead of MyUI

### DIFF
--- a/lib/sample_app/lcd_f/gt911.ex
+++ b/lib/sample_app/lcd_f/gt911.ex
@@ -82,8 +82,8 @@ defmodule SampleApp.LcdF.GT911 do
 
             Logger.info("Touch #{i}: ID=#{tid} X=#{x} Y=#{y}")
 
-            # ⭐ MyUI にメッセージ送信
-            send(MyUI, {:touch, x, y})
+            # ⭐ UI にメッセージ送信
+            send(SampleApp.LcdF.UI, {:touch, x, y})
           end
         end
 


### PR DESCRIPTION
### 概要
GT911 のタッチイベント通知先が `MyUI` となっていましたが、
実際の UI GenServer 名は `SampleApp.LcdF.UI` であるため修正しました。

### 変更内容
- `send(MyUI, {:touch, x, y})`
  → `send(SampleApp.LcdF.UI, {:touch, x, y})`

### 動作確認
タッチイベントを検出し、UI上で座標表示が更新されることを確認。
