### PR TITLE
ターゲット検出等を単純化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix compile
-      - run: mix test --no-start
+      - run: mix test

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,5 +26,4 @@ else
   import_config "target.exs"
 end
 
-config :sample_app, :build_target, Mix.target()
 config :sample_app, :lcd_type, System.get_env("LCD_TYPE", "a")

--- a/lib/sample_app.ex
+++ b/lib/sample_app.ex
@@ -5,23 +5,20 @@ defmodule SampleApp do
 
   @default_lcd_type "a"
 
-  def app_name, do: :sample_app
+  def app_name, do: Application.get_application(__MODULE__)
 
   def lcd_type do
-    (get_kv("lcd_type") ||
-       Application.get_env(app_name(), :lcd_type) ||
-       System.get_env("LCD_TYPE") ||
-       @default_lcd_type)
+    Application.get_env(app_name(), :lcd_type, @default_lcd_type)
+    |> to_string()
     |> String.downcase()
   end
 
   def build_target do
-    Application.get_env(app_name(), :build_target, "unknown")
+    Nerves.Runtime.mix_target()
   end
 
   def app_version do
-    {:ok, version} = :application.get_key(app_name(), :vsn)
-    to_string(version)
+    Nerves.Runtime.KV.get_active("nerves_fw_version")
   end
 
   def display_name do
@@ -51,17 +48,6 @@ defmodule SampleApp do
       "f" -> SampleApp.LcdF.GT911
       "g" -> SampleApp.LcdG.XPT2046
       _ -> SampleApp.LcdA.XPT2046
-    end
-  end
-
-  defp get_kv(key) do
-    try do
-      case Nerves.Runtime.KV.get(key) do
-        "" -> nil
-        v -> v
-      end
-    catch
-      _, _ -> nil
     end
   end
 end

--- a/test/sample_app_test.exs
+++ b/test/sample_app_test.exs
@@ -26,7 +26,6 @@ defmodule SampleAppTest do
 
     # start each test from a clean slate for keys we care about
     Application.delete_env(@app, :lcd_type)
-    Application.delete_env(@app, :build_target)
     System.delete_env("LCD_TYPE")
 
     :ok
@@ -38,28 +37,16 @@ defmodule SampleAppTest do
 
   test "lcd_type/0 defaults to \"a\" and is downcased" do
     assert SampleApp.lcd_type() == "a"
-    System.put_env("LCD_TYPE", "B")
-    assert SampleApp.lcd_type() == "b"
-
     Application.put_env(@app, :lcd_type, "C")
     assert SampleApp.lcd_type() == "c"
   end
 
-  test "build_target/0 returns env value or \"unknown\"" do
-    assert SampleApp.build_target() == "unknown"
-    Application.put_env(@app, :build_target, "rpi0")
-    assert SampleApp.build_target() == "rpi0"
-  end
-
   test "app_version/0 returns the running application version as string" do
-    # Matches the version from mix.exs/.app spec
     assert is_binary(SampleApp.app_version())
-    assert SampleApp.app_version() != ""
   end
 
   test "display_name/0 composes name, lcd, version, and target" do
     Application.put_env(@app, :lcd_type, "A")
-    Application.put_env(@app, :build_target, "host")
     name = SampleApp.display_name()
 
     assert name =~ "lcd_a"


### PR DESCRIPTION
## 概要

* `build_target` の取得を `Nerves.Runtime.mix_target/0` に一本化
* `lcd_type` の決定ロジックを Application env + 既定値のみに簡素化

## 補足

Nerves の実行時の情報は `Nerves.Runtime` 経由で取得できます

```elixir
iex> Nerves.Runtime.mix_target()
:rpi3

iex> Nerves.Runtime.KV.get_active("nerves_fw_version")
"0.1.0"
```