### PR TITLE
SSID取得の共通化とバックライトPWM制御の抽象化

### DIFF
--- a/lib/sample_app/backlight.ex
+++ b/lib/sample_app/backlight.ex
@@ -1,0 +1,9 @@
+defmodule SampleApp.Backlight do
+  if Mix.target() == :host do
+    def set_pwm(_gpio, _frequency, _duty_millionths), do: :ok
+  else
+    def set_pwm(gpio, frequency, duty_millionths) do
+      Pigpiox.Pwm.hardware_pwm(gpio, frequency, duty_millionths)
+    end
+  end
+end

--- a/lib/sample_app/lcd_a/ui.ex
+++ b/lib/sample_app/lcd_a/ui.ex
@@ -83,8 +83,7 @@ defmodule SampleApp.LcdA.UI do
     end)
 
     # ssidを取得して表示
-    ssid_str = current_ssid()
-    sprite_ssid = LCD.build_sprite(ssid_str, 0x0000, 0xFFFF, 2)
+    sprite_ssid = LCD.build_sprite(NetInfo.get_ssid(), 0x0000, 0xFFFF, 2)
 
     LCD.push_sprite(spi_lcd, dc, 20, 440, %{
       w: sprite_ssid.w,
@@ -103,12 +102,5 @@ defmodule SampleApp.LcdA.UI do
     LCD.push_sprite(spi_lcd, dc, 150, 1, %{w: sprite.w, h: sprite.h, pixels: sprite.pixels})
 
     {:noreply, state}
-  end
-
-  defp current_ssid do
-    case VintageNet.get(["interface", "wlan0", "wifi", "current_ap"]) do
-      %_{ssid: ssid} -> ssid
-      _ -> "No SSID"
-    end
   end
 end

--- a/lib/sample_app/lcd_b/ui.ex
+++ b/lib/sample_app/lcd_b/ui.ex
@@ -83,8 +83,7 @@ defmodule SampleApp.LcdB.UI do
     end)
 
     # ssidを取得して表示
-    ssid_str = current_ssid()
-    sprite_ssid = LCD.build_sprite(ssid_str, 0x0000, 0xFFFF, 2)
+    sprite_ssid = LCD.build_sprite(NetInfo.get_ssid(), 0x0000, 0xFFFF, 2)
 
     LCD.push_sprite(spi_lcd, dc, 20, 440, %{
       w: sprite_ssid.w,
@@ -103,12 +102,5 @@ defmodule SampleApp.LcdB.UI do
     LCD.push_sprite(spi_lcd, dc, 150, 1, %{w: sprite.w, h: sprite.h, pixels: sprite.pixels})
 
     {:noreply, state}
-  end
-
-  defp current_ssid do
-    case VintageNet.get(["interface", "wlan0", "wifi", "current_ap"]) do
-      %_{ssid: ssid} -> ssid
-      _ -> "No SSID"
-    end
   end
 end

--- a/lib/sample_app/lcd_c/ui.ex
+++ b/lib/sample_app/lcd_c/ui.ex
@@ -111,8 +111,8 @@ defmodule SampleApp.LcdC.UI do
       end)
 
     # ssidを取得して表示
-    ssid_str = current_ssid()
-    sprite_ssid = LCD.build_sprite(ssid_str, 0x0000, 0xFFFF, 2)
+    sprite_ssid = LCD.build_sprite(NetInfo.get_ssid(), 0x0000, 0xFFFF, 2)
+
     x = 20
     y = 440
 
@@ -139,12 +139,5 @@ defmodule SampleApp.LcdC.UI do
     ILI9486.display_565(display, new_buffer)
 
     {:noreply, %{state | buffer: new_buffer}}
-  end
-
-  defp current_ssid do
-    case VintageNet.get(["interface", "wlan0", "wifi", "current_ap"]) do
-      %_{ssid: ssid} -> ssid
-      _ -> "No SSID"
-    end
   end
 end

--- a/lib/sample_app/lcd_f/ui.ex
+++ b/lib/sample_app/lcd_f/ui.ex
@@ -2,6 +2,7 @@ defmodule SampleApp.LcdF.UI do
   use GenServer
   require Logger
 
+  alias SampleApp.Backlight
   alias SampleApp.LcdG.ST7796S, as: LCD
   alias SampleApp.NetInfo
   alias SampleApp.TextDraw
@@ -20,11 +21,7 @@ defmodule SampleApp.LcdF.UI do
 
     gpio = 18
     frequency = 800
-    # 100%
-    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 1_000_000)
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 500_000)   # 50%
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 100_000)   # 10%
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 10_000)    # 1%
+    Backlight.set_pwm(gpio, frequency, 1_000_000)
 
     # 背景描画
     LCD.fill_rect(spi_lcd, dc, 0, 0, 320, 480, 0xF800)
@@ -88,8 +85,7 @@ defmodule SampleApp.LcdF.UI do
     end)
 
     # ssidを取得して表示
-    ssid_str = current_ssid()
-    sprite_ssid = LCD.build_sprite(ssid_str, 0x0000, 0xFFFF, 2)
+    sprite_ssid = LCD.build_sprite(NetInfo.get_ssid(), 0x0000, 0xFFFF, 2)
 
     LCD.push_sprite(spi_lcd, dc, 20, 440, %{
       w: sprite_ssid.w,
@@ -108,12 +104,5 @@ defmodule SampleApp.LcdF.UI do
     LCD.push_sprite(spi_lcd, dc, 150, 1, %{w: sprite.w, h: sprite.h, pixels: sprite.pixels})
 
     {:noreply, state}
-  end
-
-  defp current_ssid do
-    case VintageNet.get(["interface", "wlan0", "wifi", "current_ap"]) do
-      %_{ssid: ssid} -> ssid
-      _ -> "No SSID"
-    end
   end
 end

--- a/lib/sample_app/lcd_g/ui.ex
+++ b/lib/sample_app/lcd_g/ui.ex
@@ -2,6 +2,7 @@ defmodule SampleApp.LcdG.UI do
   use GenServer
   require Logger
 
+  alias SampleApp.Backlight
   alias SampleApp.LcdG.ST7796S, as: LCD
   alias SampleApp.NetInfo
   alias SampleApp.TextDraw
@@ -20,11 +21,7 @@ defmodule SampleApp.LcdG.UI do
 
     gpio = 18
     frequency = 800
-    # 100%
-    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 1_000_000)
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 500_000)   # 50%
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 100_000)   # 10%
-    #    Pigpiox.Pwm.hardware_pwm(gpio, frequency, 10_000)    # 1%
+    Backlight.set_pwm(gpio, frequency, 1_000_000)
 
     # 背景描画
     LCD.fill_rect(spi_lcd, dc, 0, 0, 320, 480, 0xF800)
@@ -88,8 +85,7 @@ defmodule SampleApp.LcdG.UI do
     end)
 
     # ssidを取得して表示
-    ssid_str = current_ssid()
-    sprite_ssid = LCD.build_sprite(ssid_str, 0x0000, 0xFFFF, 2)
+    sprite_ssid = LCD.build_sprite(NetInfo.get_ssid(), 0x0000, 0xFFFF, 2)
 
     LCD.push_sprite(spi_lcd, dc, 20, 440, %{
       w: sprite_ssid.w,
@@ -108,12 +104,5 @@ defmodule SampleApp.LcdG.UI do
     LCD.push_sprite(spi_lcd, dc, 150, 1, %{w: sprite.w, h: sprite.h, pixels: sprite.pixels})
 
     {:noreply, state}
-  end
-
-  defp current_ssid do
-    case VintageNet.get(["interface", "wlan0", "wifi", "current_ap"]) do
-      %_{ssid: ssid} -> ssid
-      _ -> "No SSID"
-    end
   end
 end

--- a/lib/sample_app/net_info.ex
+++ b/lib/sample_app/net_info.ex
@@ -1,18 +1,29 @@
 defmodule SampleApp.NetInfo do
-  @interfaces ["eth0", "wlan0"]
+  if Mix.target() == :host do
+    def get_status_strings, do: ["foo: 0.0.0.0", "bar: 0.0.0.0"]
+    def get_ssid, do: "foo"
+    def get_ssid(_iface), do: get_ssid()
+  else
+    def get_status_strings do
+      Enum.map(["eth0", "wlan0"], fn interface ->
+        addresses = VintageNet.get(["interface", interface, "addresses"]) || []
 
-  def get_status_strings do
-    Enum.map(@interfaces, fn iface ->
-      addresses = VintageNet.get(["interface", iface, "addresses"]) || []
+        ip =
+          case Enum.find(addresses, fn a -> a[:family] == :inet end) do
+            %{address: {a, b, c, d}} -> "#{a}.#{b}.#{c}.#{d}"
+            _ -> "Waiting..."
+          end
 
-      ip =
-        case Enum.find(addresses, fn a -> a[:family] == :inet end) do
-          %{address: {a, b, c, d}} -> "#{a}.#{b}.#{c}.#{d}"
-          _ -> "Waiting..."
-        end
+        formatted_iface = String.pad_trailing(interface, 6)
+        "#{formatted_iface}: #{ip}"
+      end)
+    end
 
-      formatted_iface = String.pad_trailing(iface, 6)
-      "#{formatted_iface}: #{ip}"
-    end)
+    def get_ssid(iface \\ "wlan0") do
+      case VintageNet.get(["interface", iface, "wifi", "current_ap"]) do
+        %VintageNetWiFi.AccessPoint{ssid: ssid} -> ssid
+        _ -> "No SSID"
+      end
+    end
   end
 end


### PR DESCRIPTION
### 概要

以下のリファクタリングを実施しました。

- LCD UI 各モジュールに重複していた SSID 取得処理を共通化
  - `SampleApp.NetInfo.get_ssid/1` を追加
  - 開発ホスト（`target == :host`）ではダミーの値を返す
- バックライトの PWM 制御を `SampleApp.Backlight` に抽象化
  - 実機（`target != :host`）では `Pigpiox.Pwm.hardware_pwm/3` を呼び出し
  - 開発ホスト（`target == :host`）では何もしない実装で警告を抑制

### 変更点

- `SampleApp.NetInfo` に `get_ssid/1` を追加し、UI 側の実装を削除
- `SampleApp.Backlight` を新規追加し、直接の `Pigpiox` 呼び出しを置換
- `current_ssid()` 呼び出しを `NetInfo.get_ssid()` に置換

### 補足

- `MIX_TARGET=host` でも `NetInfo` / `Backlight` 呼び出しで警告が出ません
- `MIX_TARGET` を切り替えた場合は再コンパイル（例：`mix clean`）が必要です

### 確認方法

- `MIX_TARGET=host mix test` で警告が出ないこと
- `MIX_TARGET=host iex -S mix` で警告が出ないこと
