### PR TITLE
Dependabot を設定し、mix と GitHub Actions の依存関係を自動更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION

## 概要

Dependabot を導入し、`mix.exs` / `mix.lock` および GitHub Actions の依存関係を自動更新できるようにしました。

## 変更内容

* `.github/dependabot.yml` を追加
  * Elixir / Nerves 用 (`package-ecosystem: mix`)
  * CI 用 (`package-ecosystem: github-actions`)
  * 更新頻度は週次（`interval: weekly`）に設定

## 補足

依存関係の更新 PR は自動で作成され、`mix.lock` や Actions バージョンの追随が容易になります。
