### PR TITLE
lcd_f　バックライト起動　Backlight.start_link　に変更

### DIFF
--- a/lib/sample_app/lcd_f/ui.ex
+++ b/lib/sample_app/lcd_f/ui.ex
@@ -20,7 +20,7 @@ defmodule SampleApp.LcdF.UI do
          {:ok, dc} <- Circuits.GPIO.open(22, :output),
          {:ok, rst} <- Circuits.GPIO.open(27, :output) do
       # バックライト ON
-      {:ok, _pid} = Backlight.start(18, 1.0)
+      {:ok, _pid} = Backlight.start_link(18, 1.0)
 
       # LCD初期化
       case LCD.init(spi_lcd, dc, rst) do


### PR DESCRIPTION
ui.ex を修正

- PR #16 の実装漏れ
- 関連Issue: #12 

