### PR TITLE
LCD G 用タッチ設定の追加（0,0 を左上に揃える）

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -158,11 +158,30 @@ lcd_driver =
 touch_driver =
   case lcd_type do
     "F" ->
-      {LcdDisplay.GT911, i2c_bus: "i2c-1", interrupt_pin: 4, reset_pin: 17}
+      {LcdDisplay.GT911,
+       [
+         i2c_bus: "i2c-1",
+         interrupt_pin: 4,
+         reset_pin: 17
+       ]}
+
+    "G" ->
+      {LcdDisplay.XPT2046,
+       [
+         spi_bus: "spidev0.1",
+         interrupt_pin: 17,
+         invert_x: false,
+         invert_y: false
+       ]}
 
     _ ->
       {LcdDisplay.XPT2046,
-       spi_bus: "spidev0.1", interrupt_pin: 17, invert_x: true, invert_y: true}
+       [
+         spi_bus: "spidev0.1",
+         interrupt_pin: 17,
+         invert_x: true,
+         invert_y: true
+       ]}
   end
 
 backlight_child =


### PR DESCRIPTION
## 概要

* `lcd_type == "G"` 向けに `LcdDisplay.XPT2046` のタッチ設定を追加し、`invert_x: false`, `invert_y: false` とすることで、論理座標系を他の LCD と同様に「左上が (0,0)」になるよう調整。
* それ以外の LCD 向けの `LcdDisplay.XPT2046` 設定は従来どおり。

